### PR TITLE
Update requirements (pyup-bot)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,12 @@ setup(
     license='AGPL v3',
     install_requires=[
         'ddt>=1.1.1',
-        'Django>=1.11',
+        'Django>=1.11.3',
         'gunicorn>=19.7.1',
-        'factory-boy==2.8.1',
+        'factory-boy==2.9.0',
         'mock==2.0.0',
-        'psycopg2==2.7.1',
-        'pycountry>=17.1.8',
-        'requests>=2.13.0',
+        'psycopg2==2.7.3',
+        'pycountry>=17.5.14',
+        'requests>=2.18.2',
     ],
 )

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,10 +1,8 @@
 ddt==1.1.1
-Django==1.11
+Django==1.11.3
 gunicorn==19.7.1
-factory-boy==2.8.1
+factory-boy==2.9.0
 mock==2.0.0
-psycopg2==2.7.1
-pycountry==17.1.8
-requests==2.13.0
-psycopg2==2.7.1
-gunicorn==19.7.1
+psycopg2==2.7.3
+pycountry==17.5.14
+requests==2.18.2

--- a/web/requirements_dev.txt
+++ b/web/requirements_dev.txt
@@ -1,5 +1,5 @@
 coverage==4.4.1
-flake8==3.3.0
+flake8==3.4.1
 flake8_docstrings==1.1.0
 pep8==1.7.0
 pylint==1.7.2


### PR DESCRIPTION
1. psycopg2 to 2.7.3 — https://github.com/raccoongang/acceptor/pull/58.
2. factory-boy to 2.9.0 — https://github.com/raccoongang/acceptor/pull/57.
3. flake8 to 3.4.1 — https://github.com/raccoongang/acceptor/pull/56.
4. requests to 2.18.2 — https://github.com/raccoongang/acceptor/pull/53.
5. pylint to 1.7.2 — https://github.com/raccoongang/acceptor/pull/45.
6. pycountry to 17.5.14 — https://github.com/raccoongang/acceptor/pull/44.
7. django to 1.11.3 — https://github.com/raccoongang/acceptor/pull/43.