### PR TITLE
Fix unnecessary dumping students per country

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OLGA
 
-[![Travis](https://travis-ci.org/raccoongang/OLGA.svg?branch=master)](https://travis-ci.org/raccoongang/OLGA)
-[![Codecov](https://codecov.io/gh/raccoongang/OLGA/branch/tests%2Funit/graph/badge.svg)](https://codecov.io/gh/raccoongang/OLGA/branch/tests%2Funit)
+[![Travis](https://travis-ci.org/raccoongang/OLGA.svg?branch=develop)](https://travis-ci.org/raccoongang/OLGA)
+[![Codecov](https://codecov.io/gh/raccoongang/OLGA/branch/develop/graph/badge.svg)](https://codecov.io/gh/raccoongang/OLGA/branch/develop)
 [![Release](https://img.shields.io/github/release/raccoongang/OLGA.svg)](https://github.com/raccoongang/OLGA/releases)
 [![Code Climate](https://img.shields.io/codeclimate/github/raccoongang/OLGA.svg)](https://codeclimate.com/github/raccoongang/OLGA)
 
@@ -51,6 +51,14 @@ Environment will get bunch of linters, that you are able to use via:
 
 ```
     $ cd web && pep8 && flake8 & pylint olga && cd ..
+```
+
+### Tests
+
+To run tests use command below:
+
+```
+    $ docker-compose -f local-compose.yml run olga python manage.py test
 ```
 
 ## Production

--- a/web/olga/analytics/tests/test_views.py
+++ b/web/olga/analytics/tests/test_views.py
@@ -239,11 +239,9 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
             students_per_country, active_students_amount_day
         )
 
-        expected_students_per_country = "{\"RU\": 10, \"CA\": 5, \"UA\": 20, \"null\": 5}"
+        expected_students_per_country = {'RU': 10, 'CA': 5, 'UA': 20, 'null': 5}
 
-        self.assertDictContainsSubset(
-            json.loads(expected_students_per_country), json.loads(result)
-        )
+        self.assertDictContainsSubset(expected_students_per_country, result)
 
     def test_extend_stats_if_needed(self):
         """

--- a/web/olga/analytics/views.py
+++ b/web/olga/analytics/views.py
@@ -147,9 +147,7 @@ class ReceiveInstallationStatistics(View):
             active_students_amount_day, students_per_country_decoded
         )
 
-        students_per_country_encoded = json.dumps(students_per_country_updated)
-
-        return students_per_country_encoded
+        return students_per_country_updated
 
     def extend_stats_to_enthusiast(self, received_data, stats, edx_installation_object):
         """

--- a/web/olga/analytics/views.py
+++ b/web/olga/analytics/views.py
@@ -127,7 +127,7 @@ class ReceiveInstallationStatistics(View):
         """
         students_after_update = copy.deepcopy(students_before_update)
 
-        students_after_update['null'] = \
+        students_after_update[u'null'] = \
             active_students_amount - sum(students_after_update.values())
 
         return students_after_update

--- a/web/olga/analytics/views.py
+++ b/web/olga/analytics/views.py
@@ -127,7 +127,7 @@ class ReceiveInstallationStatistics(View):
         """
         students_after_update = copy.deepcopy(students_before_update)
 
-        students_after_update[u'null'] = \
+        students_after_update['null'] = \
             active_students_amount - sum(students_after_update.values())
 
         return students_after_update


### PR DESCRIPTION
In #67 I implemented `JSON` type for `students per country` filed instead of text type.

But I missed, that if `edX-platform` sends statistics to `OLGA` via `enthusiast` level, `OLGA` logic transform it to text (old logic). For now i got rid of unnecessary `dumps`.

