### PR TITLE
Fix getting duplicated date from the same instance

### DIFF
--- a/web/olga/analytics/models.py
+++ b/web/olga/analytics/models.py
@@ -76,22 +76,17 @@ class InstallationStatistics(models.Model):
     )
 
     @classmethod
-    def get_last_for_this_day(cls, edx_installation_object=None):
+    def get_stats_for_this_day(cls, edx_installation_object=None):
         """
+        Provide model, for given installation object, that was created today, or None if it not exist.
         :param edx_installation_object: specific installation object.
-
-        :return: None or model from db, that was created today.
         """
-        try:
-            query = cls.objects.filter(edx_installation=edx_installation_object)
-            previous_stats = query.latest('data_created_datetime')
-        # pylint: disable=maybe-no-member
-        except cls.DoesNotExist:
-            return None
-        else:
-            if previous_stats.data_created_datetime.date() != datetime.now().date():
-                return None
-        return previous_stats
+        today_midnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        query = cls.objects.filter(
+            edx_installation=edx_installation_object,
+            data_created_datetime__gt=today_midnight
+        )
+        return None if query.count() == 0 else query.last()
 
     @classmethod
     def timeline(cls):

--- a/web/olga/analytics/models.py
+++ b/web/olga/analytics/models.py
@@ -78,9 +78,10 @@ class InstallationStatistics(models.Model):
     @classmethod
     def get_stats_for_this_day(cls, edx_installation_object=None):
         """
-        Provide model, for given installation object, that was created today, or None if it not exist.
+        Provide statistic model instance for the given Edx installation.
 
         :param edx_installation_object: specific installation object.
+        :return: statistic model instance if it is created today otherwise None
         """
         today_midnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
         stat_item = cls.objects.filter(

--- a/web/olga/analytics/models.py
+++ b/web/olga/analytics/models.py
@@ -76,10 +76,16 @@ class InstallationStatistics(models.Model):
     )
 
     @classmethod
-    def get_last_for_this_day(cls, edx_installation_object):
+    def get_last_for_this_day(cls, edx_installation_object=None):
+        """
+        :param edx_installation_object: specific installation object.
+
+        :return: None or model from db, that was created today.
+        """
         try:
             query = cls.objects.filter(edx_installation=edx_installation_object)
             previous_stats = query.latest('data_created_datetime')
+        # pylint: disable=maybe-no-member
         except cls.DoesNotExist:
             return None
         else:
@@ -253,6 +259,11 @@ class InstallationStatistics(models.Model):
         return countries_amount
 
     def update(self, stats):
+        """
+        Update model from given dictionary and save it.
+
+        :param stats: dictionary with new data.
+        """
         for (key, value) in stats.items():
             setattr(self, key, value)
         self.save()

--- a/web/olga/analytics/models.py
+++ b/web/olga/analytics/models.py
@@ -5,7 +5,7 @@ Models for analytics application. Models used to store and operate all data rece
 from __future__ import division
 
 from collections import defaultdict
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 
 import pycountry
 
@@ -74,6 +74,18 @@ class InstallationStatistics(models.Model):
         help_text='This field has students country-count accordance. It follows `json` type. '
                   'Example: {"RU": 2632, "CA": 18543, "UA": 2011, "null": 1}'
     )
+
+    @classmethod
+    def get_last_for_this_day(cls, edx_installation_object):
+        try:
+            query = cls.objects.filter(edx_installation=edx_installation_object)
+            previous_stats = query.latest('data_created_datetime')
+        except cls.DoesNotExist:
+            return None
+        else:
+            if previous_stats.data_created_datetime.date() != datetime.now().date():
+                return None
+        return previous_stats
 
     @classmethod
     def timeline(cls):
@@ -239,3 +251,8 @@ class InstallationStatistics(models.Model):
         countries_amount = len(tabular_format_countries_list) - 1
 
         return countries_amount
+
+    def update(self, stats):
+        for (key, value) in stats.items():
+            setattr(self, key, value)
+        self.save()

--- a/web/olga/analytics/models.py
+++ b/web/olga/analytics/models.py
@@ -82,11 +82,11 @@ class InstallationStatistics(models.Model):
         :param edx_installation_object: specific installation object.
         """
         today_midnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        query = cls.objects.filter(
+        stat_item = cls.objects.filter(
             edx_installation=edx_installation_object,
-            data_created_datetime__gt=today_midnight
-        )
-        return None if query.count() == 0 else query.last()
+            data_created_datetime__gte=today_midnight
+        ).last()
+        return stat_item
 
     @classmethod
     def timeline(cls):

--- a/web/olga/analytics/models.py
+++ b/web/olga/analytics/models.py
@@ -79,6 +79,7 @@ class InstallationStatistics(models.Model):
     def get_stats_for_this_day(cls, edx_installation_object=None):
         """
         Provide model, for given installation object, that was created today, or None if it not exist.
+
         :param edx_installation_object: specific installation object.
         """
         today_midnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)

--- a/web/olga/analytics/tests/test_views.py
+++ b/web/olga/analytics/tests/test_views.py
@@ -325,7 +325,7 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
             mock_logger_debug
     ):
         """
-        Test logger`s debug output occurs if installation was created.
+        Test logger`s debug output occurs if installation was created and when it was updated.
         """
         edx_installation_object = EdxInstallationFactory()
 
@@ -333,11 +333,16 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
 
         ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
 
-        expected_logger_debug = [
-            ((
-                'Corresponding data was created in OLGA database.'
-            ),),
-        ]
+        expected_logger_debug = call('Corresponding data was %s in OLGA database.', 'crated')
+
+        # Factory Boy`s BaseFactory and LazyStub loggers occurs during method's logger occurs.
+        # So totally 5 loggers occurs, but only one last belongs to `create_instance_data` method.
+        # https://factoryboy.readthedocs.io/en/latest/#debugging-factory-boy
+        self.assertEqual(expected_logger_debug, mock_logger_debug.call_args_list[-1])
+
+        ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
+
+        expected_logger_debug = call('Corresponding data was %s in OLGA database.', 'updated')
 
         # Factory Boy`s BaseFactory and LazyStub loggers occurs during method's logger occurs.
         # So totally 5 loggers occurs, but only one last belongs to `create_instance_data` method.

--- a/web/olga/analytics/tests/test_views.py
+++ b/web/olga/analytics/tests/test_views.py
@@ -333,12 +333,7 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
 
         ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
 
-        expected_logger_debug = call('Corresponding data was %s in OLGA database.', 'crated')
-
-        # Factory Boy`s BaseFactory and LazyStub loggers occurs during method's logger occurs.
-        # So totally 5 loggers occurs, but only one last belongs to `create_instance_data` method.
-        # https://factoryboy.readthedocs.io/en/latest/#debugging-factory-boy
-        self.assertEqual(expected_logger_debug, mock_logger_debug.call_args_list[-1])
+        mock_logger_debug.assert_called_once_with('Corresponding data was %s in OLGA database.', 'created')
 
     @patch('olga.analytics.views.logging.Logger.debug')
     @patch('olga.analytics.models.EdxInstallation.objects.get')
@@ -357,13 +352,9 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
         ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
 
         ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
+        print mock_logger_debug.call_args_list
 
-        expected_logger_debug = call('Corresponding data was %s in OLGA database.', 'updated')
-
-        # Factory Boy`s BaseFactory and LazyStub loggers occurs during method's logger occurs.
-        # So totally 5 loggers occurs, but only one last belongs to `create_instance_data` method.
-        # https://factoryboy.readthedocs.io/en/latest/#debugging-factory-boy
-        self.assertEqual(expected_logger_debug, mock_logger_debug.call_args_list[-1])
+        mock_logger_debug.assert_any_call('Corresponding data was %s in OLGA database.', 'updated')
 
     @patch('olga.analytics.models.EdxInstallation.objects.filter')
     def test_is_token_authorized_if_instance_is_authorized(self, mock_edx_installation_objects_filter):

--- a/web/olga/analytics/tests/test_views.py
+++ b/web/olga/analytics/tests/test_views.py
@@ -325,7 +325,7 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
             mock_logger_debug
     ):
         """
-        Test logger`s debug output occurs if installation was created and when it was updated.
+        Test logger`s debug output occurs if installation was created.
         """
         edx_installation_object = EdxInstallationFactory()
 
@@ -339,6 +339,22 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
         # So totally 5 loggers occurs, but only one last belongs to `create_instance_data` method.
         # https://factoryboy.readthedocs.io/en/latest/#debugging-factory-boy
         self.assertEqual(expected_logger_debug, mock_logger_debug.call_args_list[-1])
+
+    @patch('olga.analytics.views.logging.Logger.debug')
+    @patch('olga.analytics.models.EdxInstallation.objects.get')
+    def test_logger_debug_occurs_if_stats_was_updated(
+            self,
+            mock_edx_installation_objects_get,
+            mock_logger_debug
+    ):
+        """
+        Test logger`s debug output occurs if installation was updated.
+        """
+        edx_installation_object = EdxInstallationFactory()
+
+        mock_edx_installation_objects_get.return_value = edx_installation_object
+
+        ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
 
         ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
 

--- a/web/olga/analytics/tests/test_views.py
+++ b/web/olga/analytics/tests/test_views.py
@@ -352,7 +352,6 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
         ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
 
         ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
-        print mock_logger_debug.call_args_list
 
         mock_logger_debug.assert_any_call('Corresponding data was %s in OLGA database.', 'updated')
 
@@ -500,7 +499,7 @@ class TestReceiveInstallationStatistics(TestCase):
 
     def test_multiply_create_instance_data_in_same_day(self):
         """
-        Verify that when twice call sending statistic from one instance only one record will be created.
+        Verify that when twice calls are sent statistic from one instance only one record will be created.
         """
         self.client.post('/api/installation/statistics/', self.received_data)
         self.assertEqual(1, InstallationStatistics.objects.all().count())
@@ -516,7 +515,7 @@ class TestReceiveInstallationStatistics(TestCase):
 
     def test_multiply_create_instance_data_in_different_day(self):
         """
-        Verify that when twice call sending statistic in different days there are two records will be created.
+        Verify that when twice calls are sent statistic in different days there are two records will be created.
         """
         self.client.post('/api/installation/statistics/', self.received_data)
         stats = InstallationStatistics.objects.all()

--- a/web/olga/analytics/tests/test_views.py
+++ b/web/olga/analytics/tests/test_views.py
@@ -6,7 +6,6 @@ import copy
 import httplib
 import json
 import uuid
-import logging
 from datetime import datetime, timedelta
 
 from mock import patch, call

--- a/web/olga/analytics/tests/test_views.py
+++ b/web/olga/analytics/tests/test_views.py
@@ -341,8 +341,8 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
 
         expected_logger_debug = [
             ((
-                 'Corresponding data was created in OLGA database.'
-             ),),
+                'Corresponding data was created in OLGA database.'
+            ),),
         ]
 
         # Factory Boy`s BaseFactory and LazyStub loggers occurs during method's logger occurs.
@@ -493,6 +493,9 @@ class TestReceiveInstallationStatistics(TestCase):
         mock_create_instance_data.assert_called_once_with(self.received_data_as_query_dict, self.access_token)
 
     def test_multiply_create_instance_data_in_same_day(self):
+        """
+        Verify that when twice call sending statistic from one instance only one record will be created.
+        """
         self.client.post('/api/installation/statistics/', self.received_data)
         self.assertEqual(1, InstallationStatistics.objects.all().count())
 
@@ -505,6 +508,9 @@ class TestReceiveInstallationStatistics(TestCase):
             stats[0].active_students_amount_day)
 
     def test_multiply_create_instance_data_in_different_day(self):
+        """
+        Verify that when twice call sending statistic in different day there are two records will be created.
+        """
         self.client.post('/api/installation/statistics/', self.received_data)
         stats = InstallationStatistics.objects.all()
         self.assertEqual(1, stats.count())

--- a/web/olga/analytics/tests/test_views.py
+++ b/web/olga/analytics/tests/test_views.py
@@ -27,11 +27,6 @@ from olga.analytics.views import (
 
 # pylint: disable=invalid-name
 
-logging.basicConfig()
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
 
 class MockUUID4(object):  # pylint: disable=too-few-public-methods
     """
@@ -414,7 +409,7 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
         expected_logger_debugs = [
             call((
                 json.dumps(self.received_data, sort_keys=True, indent=4)
-            ), ),
+            ),),
         ]
 
         self.assertEqual(expected_logger_debugs, mock_logger_debug.call_args_list)
@@ -505,11 +500,12 @@ class TestReceiveInstallationStatistics(TestCase):
         self.assertEqual(1, stats.count())
         self.assertEqual(
             int(self.received_data['active_students_amount_day']),
-            stats[0].active_students_amount_day)
+            stats[0].active_students_amount_day
+        )
 
     def test_multiply_create_instance_data_in_different_day(self):
         """
-        Verify that when twice call sending statistic in different day there are two records will be created.
+        Verify that when twice call sending statistic in different days there are two records will be created.
         """
         self.client.post('/api/installation/statistics/', self.received_data)
         stats = InstallationStatistics.objects.all()

--- a/web/olga/analytics/tests/test_views.py
+++ b/web/olga/analytics/tests/test_views.py
@@ -499,7 +499,7 @@ class TestReceiveInstallationStatistics(TestCase):
 
     def test_multiply_create_instance_data_in_same_day(self):
         """
-        Verify that when twice calls are sent statistic from one instance only one record will be created.
+        Verify that when double calls are sent statistic from one instance only one record will be created.
         """
         self.client.post('/api/installation/statistics/', self.received_data)
         self.assertEqual(1, InstallationStatistics.objects.all().count())
@@ -515,7 +515,7 @@ class TestReceiveInstallationStatistics(TestCase):
 
     def test_multiply_create_instance_data_in_different_day(self):
         """
-        Verify that when twice calls are sent statistic in different days there are two records will be created.
+        Verify that when double calls are sent statistic in different days there are two records will be created.
         """
         self.client.post('/api/installation/statistics/', self.received_data)
         stats = InstallationStatistics.objects.all()

--- a/web/olga/analytics/views.py
+++ b/web/olga/analytics/views.py
@@ -211,11 +211,13 @@ class ReceiveInstallationStatistics(View):
             self.extend_stats_to_enthusiast(received_data, stats, edx_installation_object)
 
         previous_stats = InstallationStatistics.get_stats_for_this_day(edx_installation_object)
+        log_msg = 'Corresponding data was %s in OLGA database.'
         if previous_stats:
             previous_stats.update(stats)
+            logger.debug(log_msg, 'updated')
         else:
             InstallationStatistics.objects.create(edx_installation=edx_installation_object, **stats)
-        logger.debug('Corresponding data was created in OLGA database.')
+            logger.debug(log_msg, 'crated')
 
     @staticmethod
     def log_debug_instance_details(received_data):

--- a/web/olga/analytics/views.py
+++ b/web/olga/analytics/views.py
@@ -8,7 +8,6 @@ import json
 import logging
 from uuid import uuid4
 
-from datetime import datetime
 from django.http import HttpResponse
 from django.http import JsonResponse
 from django.views.generic import View

--- a/web/olga/analytics/views.py
+++ b/web/olga/analytics/views.py
@@ -217,7 +217,7 @@ class ReceiveInstallationStatistics(View):
             logger.debug(log_msg, 'updated')
         else:
             InstallationStatistics.objects.create(edx_installation=edx_installation_object, **stats)
-            logger.debug(log_msg, 'crated')
+            logger.debug(log_msg, 'created')
 
     @staticmethod
     def log_debug_instance_details(received_data):

--- a/web/olga/analytics/views.py
+++ b/web/olga/analytics/views.py
@@ -8,6 +8,7 @@ import json
 import logging
 from uuid import uuid4
 
+from datetime import datetime
 from django.http import HttpResponse
 from django.http import JsonResponse
 from django.views.generic import View
@@ -210,7 +211,11 @@ class ReceiveInstallationStatistics(View):
         if statistics_level == 'enthusiast':
             self.extend_stats_to_enthusiast(received_data, stats, edx_installation_object)
 
-        InstallationStatistics.objects.create(edx_installation=edx_installation_object, **stats)
+        previous_stats = InstallationStatistics.get_last_for_this_day(edx_installation_object)
+        if previous_stats:
+            previous_stats.update(stats)
+        else:
+            InstallationStatistics.objects.create(edx_installation=edx_installation_object, **stats)
         logger.debug('Corresponding data was created in OLGA database.')
 
     @staticmethod

--- a/web/olga/analytics/views.py
+++ b/web/olga/analytics/views.py
@@ -210,7 +210,7 @@ class ReceiveInstallationStatistics(View):
         if statistics_level == 'enthusiast':
             self.extend_stats_to_enthusiast(received_data, stats, edx_installation_object)
 
-        previous_stats = InstallationStatistics.get_last_for_this_day(edx_installation_object)
+        previous_stats = InstallationStatistics.get_stats_for_this_day(edx_installation_object)
         if previous_stats:
             previous_stats.update(stats)
         else:

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,5 +1,5 @@
 ddt==1.1.1
-Django==1.11.3
+Django==1.11.5
 gunicorn==19.7.1
 factory-boy==2.9.0
 mock==2.0.0


### PR DESCRIPTION
Previously, when same instance send statistic more than one time per day - it stored in different records in database.
We propose update record when we already have statistic for this day for avoid dublication.