### PR TITLE
Fix multistatistic per day

### DIFF
--- a/web/olga/analytics/models.py
+++ b/web/olga/analytics/models.py
@@ -5,7 +5,7 @@ Models for analytics application. Models used to store and operate all data rece
 from __future__ import division
 
 from collections import defaultdict
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta
 
 import pycountry
 
@@ -74,21 +74,6 @@ class InstallationStatistics(models.Model):
         help_text='This field has students country-count accordance. It follows `json` type. '
                   'Example: {"RU": 2632, "CA": 18543, "UA": 2011, "null": 1}'
     )
-
-    @classmethod
-    def get_stats_for_this_day(cls, edx_installation_object=None):
-        """
-        Provide statistic model instance for the given Edx installation.
-
-        :param edx_installation_object: specific installation object.
-        :return: statistic model instance if it is created today otherwise None
-        """
-        today_midnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        stat_item = cls.objects.filter(
-            edx_installation=edx_installation_object,
-            data_created_datetime__gte=today_midnight
-        ).last()
-        return stat_item
 
     @classmethod
     def timeline(cls):
@@ -254,13 +239,3 @@ class InstallationStatistics(models.Model):
         countries_amount = len(tabular_format_countries_list) - 1
 
         return countries_amount
-
-    def update(self, stats):
-        """
-        Update model from given dictionary and save it.
-
-        :param stats: dictionary with new data.
-        """
-        for (key, value) in stats.items():
-            setattr(self, key, value)
-        self.save()

--- a/web/olga/analytics/models.py
+++ b/web/olga/analytics/models.py
@@ -5,7 +5,7 @@ Models for analytics application. Models used to store and operate all data rece
 from __future__ import division
 
 from collections import defaultdict
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 
 import pycountry
 
@@ -74,6 +74,21 @@ class InstallationStatistics(models.Model):
         help_text='This field has students country-count accordance. It follows `json` type. '
                   'Example: {"RU": 2632, "CA": 18543, "UA": 2011, "null": 1}'
     )
+
+    @classmethod
+    def get_stats_for_this_day(cls, edx_installation_object=None):
+        """
+        Provide statistic model instance for the given Edx installation.
+
+        :param edx_installation_object: specific installation object.
+        :return: statistic model instance if it is created today otherwise None
+        """
+        today_midnight = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        stat_item = cls.objects.filter(
+            edx_installation=edx_installation_object,
+            data_created_datetime__gte=today_midnight
+        ).last()
+        return stat_item
 
     @classmethod
     def timeline(cls):
@@ -239,3 +254,13 @@ class InstallationStatistics(models.Model):
         countries_amount = len(tabular_format_countries_list) - 1
 
         return countries_amount
+
+    def update(self, stats):
+        """
+        Update model from given dictionary and save it.
+
+        :param stats: dictionary with new data.
+        """
+        for (key, value) in stats.items():
+            setattr(self, key, value)
+        self.save()

--- a/web/olga/analytics/tests/test_views.py
+++ b/web/olga/analytics/tests/test_views.py
@@ -6,6 +6,7 @@ import copy
 import httplib
 import json
 import uuid
+from datetime import datetime, timedelta
 
 from mock import patch, call
 
@@ -14,7 +15,7 @@ from django.http import QueryDict
 from django.test import TestCase
 from django.utils.encoding import force_text
 
-from olga.analytics.models import EdxInstallation
+from olga.analytics.models import EdxInstallation, InstallationStatistics
 from olga.analytics.tests.factories import EdxInstallationFactory
 
 from olga.analytics.views import (
@@ -332,16 +333,27 @@ class TestReceiveInstallationStatisticsHelpers(TestCase):
 
         ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
 
-        expected_logger_debug = [
-            ((
-                'Corresponding data was created in OLGA database.'
-            ),),
-        ]
+        mock_logger_debug.assert_called_once_with('Corresponding data was %s in OLGA database.', 'created')
 
-        # Factory Boy`s BaseFactory and LazyStub loggers occurs during method's logger occurs.
-        # So totally 5 loggers occurs, but only one last belongs to `create_instance_data` method.
-        # https://factoryboy.readthedocs.io/en/latest/#debugging-factory-boy
-        self.assertEqual(expected_logger_debug, mock_logger_debug.call_args_list[-1])
+    @patch('olga.analytics.views.logging.Logger.debug')
+    @patch('olga.analytics.models.EdxInstallation.objects.get')
+    def test_logger_debug_occurs_if_stats_was_updated(
+            self,
+            mock_edx_installation_objects_get,
+            mock_logger_debug
+    ):
+        """
+        Test logger`s debug output occurs if installation was updated.
+        """
+        edx_installation_object = EdxInstallationFactory()
+
+        mock_edx_installation_objects_get.return_value = edx_installation_object
+
+        ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
+
+        ReceiveInstallationStatistics().create_instance_data(self.received_data, self.access_token)
+
+        mock_logger_debug.assert_any_call('Corresponding data was %s in OLGA database.', 'updated')
 
     @patch('olga.analytics.models.EdxInstallation.objects.filter')
     def test_is_token_authorized_if_instance_is_authorized(self, mock_edx_installation_objects_filter):
@@ -484,3 +496,31 @@ class TestReceiveInstallationStatistics(TestCase):
         """
         self.client.post('/api/installation/statistics/', self.received_data)
         mock_create_instance_data.assert_called_once_with(self.received_data_as_query_dict, self.access_token)
+
+    def test_multiply_create_instance_data_in_same_day(self):
+        """
+        Verify that when double calls are sent statistic from one instance only one record will be created.
+        """
+        self.client.post('/api/installation/statistics/', self.received_data)
+        self.assertEqual(1, InstallationStatistics.objects.all().count())
+
+        self.received_data['active_students_amount_day'] *= 2
+        self.client.post('/api/installation/statistics/', self.received_data)
+        stats = InstallationStatistics.objects.all()
+        self.assertEqual(1, stats.count())
+        self.assertEqual(
+            int(self.received_data['active_students_amount_day']),
+            stats[0].active_students_amount_day
+        )
+
+    def test_multiply_create_instance_data_in_different_day(self):
+        """
+        Verify that when double calls are sent statistic in different days there are two records will be created.
+        """
+        self.client.post('/api/installation/statistics/', self.received_data)
+        stats = InstallationStatistics.objects.all()
+        self.assertEqual(1, stats.count())
+        stats.update(data_created_datetime=(datetime.now() - timedelta(days=1)))
+
+        self.client.post('/api/installation/statistics/', self.received_data)
+        self.assertEqual(2, InstallationStatistics.objects.all().count())

--- a/web/olga/analytics/views.py
+++ b/web/olga/analytics/views.py
@@ -210,14 +210,8 @@ class ReceiveInstallationStatistics(View):
         if statistics_level == 'enthusiast':
             self.extend_stats_to_enthusiast(received_data, stats, edx_installation_object)
 
-        previous_stats = InstallationStatistics.get_stats_for_this_day(edx_installation_object)
-        log_msg = 'Corresponding data was %s in OLGA database.'
-        if previous_stats:
-            previous_stats.update(stats)
-            logger.debug(log_msg, 'updated')
-        else:
-            InstallationStatistics.objects.create(edx_installation=edx_installation_object, **stats)
-            logger.debug(log_msg, 'created')
+        InstallationStatistics.objects.create(edx_installation=edx_installation_object, **stats)
+        logger.debug('Corresponding data was created in OLGA database.')
 
     @staticmethod
     def log_debug_instance_details(received_data):

--- a/web/olga/analytics/views.py
+++ b/web/olga/analytics/views.py
@@ -210,8 +210,14 @@ class ReceiveInstallationStatistics(View):
         if statistics_level == 'enthusiast':
             self.extend_stats_to_enthusiast(received_data, stats, edx_installation_object)
 
-        InstallationStatistics.objects.create(edx_installation=edx_installation_object, **stats)
-        logger.debug('Corresponding data was created in OLGA database.')
+        previous_stats = InstallationStatistics.get_stats_for_this_day(edx_installation_object)
+        log_msg = 'Corresponding data was %s in OLGA database.'
+        if previous_stats:
+            previous_stats.update(stats)
+            logger.debug(log_msg, 'updated')
+        else:
+            InstallationStatistics.objects.create(edx_installation=edx_installation_object, **stats)
+            logger.debug(log_msg, 'created')
 
     @staticmethod
     def log_debug_instance_details(received_data):

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,5 +1,5 @@
 ddt==1.1.1
-Django==1.11.5
+Django==1.11.3
 gunicorn==19.7.1
 factory-boy==2.9.0
 mock==2.0.0

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,5 +1,5 @@
 ddt==1.1.1
-Django==1.11.3
+Django==1.11.5
 gunicorn==19.7.1
 factory-boy==2.9.0
 mock==2.0.0


### PR DESCRIPTION
Previously, when same instance send statistic more than one time per day - it stored in different records in database.
We propose update record when we already have statistic for this day for avoid dublication.