### PR TITLE
Added catching for undefined country code

### DIFF
--- a/web/olga/analytics/models.py
+++ b/web/olga/analytics/models.py
@@ -203,10 +203,11 @@ class InstallationStatistics(models.Model):
             student_amount_percentage = cls.get_student_amount_percentage(count, all_active_students)
 
             try:
-                country_alpha_3 = str(pycountry.countries.get(alpha_2=country).alpha_3)
+                country_info = pycountry.countries.get(alpha_2=country)
+                country_alpha_3 = str(country_info.alpha_3)
                 datamap_format_countries_list += [[country_alpha_3, count]]
 
-                country_name = str(pycountry.countries.get(alpha_2=country).name)
+                country_name = str(country_info.name)
                 tabular_format_countries_list += [[country_name, count, student_amount_percentage]]
             except KeyError:
                 # Create students without country amount.

--- a/web/olga/analytics/models.py
+++ b/web/olga/analytics/models.py
@@ -202,14 +202,13 @@ class InstallationStatistics(models.Model):
         for country, count in worlds_students_per_country.iteritems():
             student_amount_percentage = cls.get_student_amount_percentage(count, all_active_students)
 
-            if country != 'null':
+            try:
                 country_alpha_3 = str(pycountry.countries.get(alpha_2=country).alpha_3)
                 datamap_format_countries_list += [[country_alpha_3, count]]
 
                 country_name = str(pycountry.countries.get(alpha_2=country).name)
                 tabular_format_countries_list += [[country_name, count, student_amount_percentage]]
-
-            else:
+            except KeyError:
                 # Create students without country amount.
                 tabular_format_countries_list += [['Unset', count, student_amount_percentage]]
 


### PR DESCRIPTION
Fix bug on the `map` page.

In case, when student’s statistics are collected with the incorrect country, previous implementation raises error. This PR fixes it by set student country to the `Unset` list.